### PR TITLE
Fixing get method and updating tests

### DIFF
--- a/Tests/InputTest.php
+++ b/Tests/InputTest.php
@@ -28,6 +28,14 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	private $instance;
 
 	/**
+	 * The mock filter object
+	 *
+	 * @var    FilterInputMock
+	 * @since  1.0
+	 */
+	private $filterMock;
+
+	/**
 	 * Test the Joomla\Input\Input::__construct method.
 	 *
 	 * @return  void
@@ -63,127 +71,179 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function test__get()
 	{
-		// Test super globals
-		$_POST['foo'] = 'bar';
+		$instance = $this->getInputObject(array());
 
-		// Test the get method.
-		$this->assertThat(
-			$this->instance->post->get('foo'),
-			$this->equalTo('bar'),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		// Test the set method.
-		$this->instance->post->set('foo', 'notbar');
-		$this->assertThat(
-			$this->instance->post->get('foo'),
-			$this->equalTo('notbar'),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		$_GET['foo'] = 'bar';
-
-		// Test the get method.
-		$this->assertThat(
-			$this->instance->get->get('foo'),
-			$this->equalTo('bar')
-		);
-
-		// Test the set method.
-		$this->instance->get->set('foo', 'notbar');
-		$this->assertThat(
-			$this->instance->get->get('foo'),
-			$this->equalTo('notbar')
-		);
-
-		// Test input class Cli
-		$this->instance->cli->set('foo', 'bar');
-		$this->assertThat(
-			$this->instance->cli->get('foo'),
-			$this->equalTo('bar')
-		);
-
-		// Test input class Json
-		$this->instance->json->set('foo', 'bar');
-		$this->assertThat(
-			$this->instance->json->get('foo'),
-			$this->equalTo('bar')
-		);
-
-		// Input classes Cookie and Files yet to be completed
-		$this->markTestIncomplete();
+		$this->assertAttributeEquals($_GET, 'data', $instance->get);
 	}
 
 	/**
-	 * Test the Joomla\Input\Input::count method.
+	 * Test the Joomla\Input\Input::count method with no data.
 	 *
 	 * @return  void
 	 *
 	 * @covers  Joomla\Input\Input::count
 	 * @since   1.0
 	 */
-	public function testCount()
+	public function testCountWithNoData()
 	{
-		$this->assertEquals(
-			count($_REQUEST),
-			count($this->instance)
-		);
+		$instance = $this->getInputObject(array());
 
 		$this->assertEquals(
-			count($_POST),
-			count($this->instance->post)
-		);
-
-		$this->assertEquals(
-			count($_GET),
-			count($this->instance->get)
+			0,
+			$instance->count()
 		);
 	}
 
 	/**
-	 * Test the Joomla\Input\Input::get method.
+	 * Test the Joomla\Input\Input::count method with data.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::count
+	 * @since   1.0
+	 */
+	public function testCountWithData()
+	{
+		$instance = $this->getInputObject(array('foo' => 2, 'bar' => 3, 'gamma' => 4));
+
+		$this->assertEquals(
+			3,
+			$instance->count()
+		);
+	}
+
+	/**
+	 * Test the Joomla\Input\Input::get method with a normal value.
 	 *
 	 * @return  void
 	 *
 	 * @covers  Joomla\Input\Input::get
 	 * @since   1.0
 	 */
-	public function testGet()
+	public function testGetWithStandardValue()
 	{
-		$_REQUEST['foo'] = 'bar';
+		$instance = $this->getInputObject(array('foo' => 'bar'));
 
-		$instance = new Input;
+		$this->assertEquals(
+			'bar',
+			$instance->get('foo')
+		);
+	}
+
+	/**
+	 * Test the Joomla\Input\Input::get method with empty string.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::get
+	 * @since   1.0
+	 */
+	public function testGetWithEmptyString()
+	{
+		$instance = $this->getInputObject(array('foo' => ''));
+
+		$this->assertEquals(
+			'',
+			$instance->get('foo')
+		);
+
+		$this->assertInternalType('string', $instance->get('foo'));
+	}
+
+	/**
+	 * Test the Joomla\Input\Input::get method with integer 0.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::get
+	 * @since   1.0
+	 */
+	public function testGetWith0()
+	{
+		$instance = $this->getInputObject(array('foo' => 0));
+
+		$this->assertEquals(
+			0,
+			$instance->getInt('foo')
+		);
+
+		$this->assertInternalType('integer', $instance->get('foo'));
+	}
+
+	/**
+	 * Test the Joomla\Input\Input::get method with float 0.0.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::get
+	 * @since   1.0
+	 */
+	public function testGetWith0Point0()
+	{
+		$instance = $this->getInputObject(array('foo' => 0.0));
+
+		$this->assertEquals(
+			0.0,
+			$instance->getFloat('foo')
+		);
+
+		$this->assertInternalType('float', $instance->get('foo'));
+	}
+
+	/**
+	 * Test the Joomla\Input\Input::get method with string "0".
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::get
+	 * @since   1.0
+	 */
+	public function testGetWithString0()
+	{
+		$instance = $this->getInputObject(array('foo' => "0"));
+
+		$this->assertEquals(
+			"0",
+			$instance->get('foo')
+		);
+
+		$this->assertInternalType('string', $instance->get('foo'));
+	}
+
+	/**
+	 * Test the Joomla\Input\Input::get method with false.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::get
+	 * @since   1.0
+	 */
+	public function testGetWithFalse()
+	{
+		$instance = $this->getInputObject(array('foo' => false));
+
+		$this->assertEquals(
+			false,
+			$instance->getBoolean('foo')
+		);
+
+		$this->assertInternalType('boolean', $instance->get('foo'));
+	}
+
+	/**
+	 * Tests retrieving a default value..
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::get
+	 * @since   1.0
+	 */
+	public function testGetDefault()
+	{
+		$instance = $this->getInputObject(array('foo' => 'bar'));
 
 		// Test the get method.
-		$this->assertThat(
-			$instance->get('foo'),
-			$this->equalTo('bar'),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		$_GET['foo'] = 'bar2';
-
-		// Test the get method.
-		$this->assertThat(
-			$instance->get->get('foo'),
-			$this->equalTo('bar2'),
-			'Checks first use of new super-global.'
-		);
-
-		// Test the get method.
-		$this->assertThat(
-			$instance->get('default_value', 'default'),
-			$this->equalTo('default'),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		$_REQUEST['empty'] = '';
-
-		// Test the get method
-		$this->assertThat(
-			$instance->get('empty', 'default'),
-			$this->equalTo('default')
-		);
+		$this->assertEquals('default', $instance->get('default_value', 'default'));
 	}
 
 	/**
@@ -194,21 +254,30 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 * @covers  Joomla\Input\Input::def
 	 * @since   1.0
 	 */
-	public function testDef()
+	public function testDefNotReadWhenValueExists()
 	{
-		$_REQUEST['foo'] = 'bar';
+		$instance = $this->getInputObject(array('foo' => 'bar'));
 
-		$this->instance->def('foo', 'nope');
+		$instance->def('foo', 'nope');
 
-		$this->assertThat(
-			$_REQUEST['foo'],
-			$this->equalTo('bar'),
-			'Line: ' . __LINE__ . '.'
-		);
+		$this->assertEquals('bar', $instance->get('foo'));
+	}
 
-		$this->instance->def('Joomla', 'is great');
+	/**
+	 * Test the Joomla\Input\Input::def method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::def
+	 * @since   1.0
+	 */
+	public function testDefRead()
+	{
+		$instance = $this->getInputObject(array('foo' => 'bar'));
 
-		$this->assertArrayNotHasKey('Joomla', $_REQUEST, 'Checks super-global was not modified.');
+		$instance->def('bar', 'nope');
+
+		$this->assertEquals('nope', $instance->get('bar'));
 	}
 
 	/**
@@ -221,18 +290,15 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testSet()
 	{
-		$_REQUEST['foo'] = 'bar2';
-		$this->instance->set('foo', 'bar');
+		$instance = $this->getInputObject(array('foo' => 'bar'));
 
-		$this->assertThat(
-			$_REQUEST['foo'],
-			$this->equalTo('bar2'),
-			'Line: ' . __LINE__ . '.'
-		);
+		$instance->set('foo', 'gamma');
+
+		$this->assertEquals('gamma', $instance->get('foo'));
 	}
 
 	/**
-	 * Test the Joomla\Input\Input::get method.
+	 * Test the Joomla\Input\Input::getArray method.
 	 *
 	 * @return  void
 	 *
@@ -241,43 +307,21 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetArray()
 	{
-		$filterMock = new FilterInputMock;
-
 		$array = array(
 			'var1' => 'value1',
 			'var2' => 34,
 			'var3' => array('test')
 		);
-		$input = new Input(
-			$array,
-			array('filter' => $filterMock)
-		);
 
-		$this->assertThat(
-			$input->getArray(
-				array('var1' => 'filter1', 'var2' => 'filter2', 'var3' => 'filter3')
-			),
-			$this->equalTo(array('var1' => 'value1', 'var2' => 34, 'var3' => array('test'))),
-			'Line: ' . __LINE__ . '.'
-		);
+		$input = $this->getInputObject($array);
 
-		$this->assertThat(
-			$filterMock->calls['clean'][0],
-			$this->equalTo(array('value1', 'filter1')),
-			'Line: ' . __LINE__ . '.'
-		);
+		$this->assertEquals($array, $input->getArray(
+			array('var1' => 'filter1', 'var2' => 'filter2', 'var3' => 'filter3')
+		));
 
-		$this->assertThat(
-			$filterMock->calls['clean'][1],
-			$this->equalTo(array(34, 'filter2')),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		$this->assertThat(
-			$filterMock->calls['clean'][2],
-			$this->equalTo(array(array('test'), 'filter3')),
-			'Line: ' . __LINE__ . '.'
-		);
+		$this->assertEquals(array('value1', 'filter1'), $this->filterMock->calls['clean'][0]);
+		$this->assertEquals(array(34, 'filter2'), $this->filterMock->calls['clean'][1]);
+		$this->assertEquals(array(array('test'), 'filter3'), $this->filterMock->calls['clean'][2]);
 	}
 
 	/**
@@ -290,44 +334,23 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetArrayNested()
 	{
-		$filterMock = new FilterInputMock;
-
 		$array = array(
 			'var2' => 34,
 			'var3' => array('var2' => 'test'),
 			'var4' => array('var1' => array('var2' => 'test'))
 		);
-		$input = new Input(
-			$array,
-			array('filter' => $filterMock)
-		);
 
-		$this->assertThat(
+		$input = $this->getInputObject($array);
+
+		$this->assertEquals(
+			array('var4' => array('var1' => array('var2' => 'test'))),
 			$input->getArray(
-				array('var2' => 'filter2', 'var3' => array('var2' => 'filter3'))
-			),
-			$this->equalTo(array('var2' => 34, 'var3' => array('var2' => 'test'))),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		$this->assertThat(
-			$input->getArray(
-				array('var4' => array('var1' => array('var2' => 'filter1')))
-			),
-			$this->equalTo(array('var4' => array('var1' => array('var2' => 'test')))),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		$this->assertThat(
-			$filterMock->calls['clean'][0],
-			$this->equalTo(array(34, 'filter2')),
-			'Line: ' . __LINE__ . '.'
-		);
-
-		$this->assertThat(
-			$filterMock->calls['clean'][1],
-			$this->equalTo(array(array('var2' => 'test'), 'array')),
-			'Line: ' . __LINE__ . '.'
+				array(
+					'var4' => array(
+						'var1' => array('var2' => 'test')
+					)
+				)
+			)
 		);
 	}
 
@@ -350,7 +373,7 @@ class InputTest extends \PHPUnit_Framework_TestCase
 			'var7' => null
 		);
 
-		$input = new Input($array);
+		$input = $this->getInputObject($array);
 
 		$this->assertEquals($input->getArray(), $array);
 	}
@@ -365,21 +388,11 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetFromCookie()
 	{
-		// Check the object type.
-		$this->assertThat(
-			$this->instance->cookie instanceof Cookie,
-			$this->isTrue(),
-			'Line: ' . __LINE__ . '.'
-		);
+		$instance = $this->getInputObject(array());
 
 		$_COOKIE['foo'] = 'bar';
 
-		// Test the get method.
-		$this->assertThat(
-			$this->instance->cookie->get('foo'),
-			$this->equalTo('bar'),
-			'Line: ' . __LINE__ . '.'
-		);
+		$this->assertAttributeEquals($_COOKIE, 'data', $instance->cookie);
 	}
 
 	/**
@@ -392,7 +405,11 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetMethod()
 	{
-		$this->markTestIncomplete();
+		$_SERVER['REQUEST_METHOD'] = 'custom';
+
+		$instance = $this->getInputObject(array());
+
+		$this->assertEquals('CUSTOM', $instance->getMethod());
 	}
 
 	/**
@@ -405,16 +422,18 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testSerialize()
 	{
+		$instance = $this->getInputObject(array());
+
 		// Load the inputs so that the static $loaded is set to true.
-		TestHelper::invoke($this->instance, 'loadAllInputs');
+		TestHelper::invoke($instance, 'loadAllInputs');
 
 		// Adjust the values so they are easier to handle.
-		TestHelper::setValue($this->instance, 'inputs', array('server' => 'remove', 'env' => 'remove', 'request' => 'keep'));
-		TestHelper::setValue($this->instance, 'options', 'options');
-		TestHelper::setValue($this->instance, 'data', 'data');
+		TestHelper::setValue($instance, 'inputs', array('server' => 'remove', 'env' => 'remove', 'request' => 'keep'));
+		TestHelper::setValue($instance, 'options', 'options');
+		TestHelper::setValue($instance, 'data', 'data');
 
 		$this->assertThat(
-			$this->instance->serialize(),
+			$instance->serialize(),
 			$this->equalTo('a:3:{i:0;s:7:"options";i:1;s:4:"data";i:2;a:1:{s:7:"request";s:4:"keep";}}')
 		);
 	}
@@ -429,24 +448,25 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testUnserialize()
 	{
-		$this->markTestIncomplete();
+		$serialized = 'a:3:{i:0;s:7:"options";i:1;s:4:"data";i:2;a:1:{s:7:"request";s:4:"keep";}}';
+
+		$instance = $this->getInputObject(array());
+
+		$instance->unserialize($serialized);
+
+		$this->assertAttributeEquals('data', 'data', $instance);
 	}
 
-	/*
-	 * Protected methods.
-	 */
-
 	/**
-	 * Test the Joomla\Input\Input::loadAllInputs method.
+	 * Get Input object populated with passed in data
 	 *
-	 * @return  void
+	 * @return  Input
 	 *
-	 * @covers  Joomla\Input\Input::loadAllInputs
 	 * @since   1.0
 	 */
-	public function testLoadAllInputs()
+	protected function getInputObject($data)
 	{
-		$this->markTestIncomplete();
+		return new Input($data, array('filter' => $this->filterMock));
 	}
 
 	/**
@@ -460,7 +480,6 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	{
 		parent::setUp();
 
-		$array = null;
-		$this->instance = new Input($array, array('filter' => new FilterInputMock));
+		$this->filterMock = new FilterInputMock;
 	}
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -167,7 +167,7 @@ class Input implements \Serializable, \Countable
 	 */
 	public function get($name, $default = null, $filter = 'cmd')
 	{
-		if (isset($this->data[$name]) && !empty($this->data[$name]))
+		if (isset($this->data[$name]))
 		{
 			return $this->filter->clean($this->data[$name], $filter);
 		}


### PR DESCRIPTION
An issue was introduced that made it impossible to read the following values from the request:
0
'0'
false
array()
0.0
''

This pull request fixes this issue, as well as adding tests for these conditions.  I've also updated the tests so that we are only testing one thing per test and to clean the code up a bit.
