### PR TITLE
If we get null back from the filter then return the default value

### DIFF
--- a/Tests/InputTest.php
+++ b/Tests/InputTest.php
@@ -225,6 +225,26 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Test the Joomla\Input\Input::get method with integer 0.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Input\Input::get
+	 * @since   1.0
+	 */
+	public function testGetIntegerWithNullString()
+	{
+		$instance = $this->getInputObject(array('foo' => ''));
+
+		$this->assertEquals(
+			0,
+			$instance->getInt('foo', 0, 'INTEGER')
+		);
+
+		$this->assertInternalType('integer', $instance->get('foo', 0, 'INTEGER'));
+	}
+
+	/**
 	 * Test the Joomla\Input\Input::get method with float 0.0.
 	 *
 	 * @return  void

--- a/Tests/InputTest.php
+++ b/Tests/InputTest.php
@@ -225,26 +225,6 @@ class InputTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the Joomla\Input\Input::get method with integer 0.
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\Input\Input::get
-	 * @since   1.0
-	 */
-	public function testGetIntegerWithNullString()
-	{
-		$instance = $this->getInputObject(array('foo' => ''));
-
-		$this->assertEquals(
-			0,
-			$instance->getInt('foo', 0, 'INTEGER')
-		);
-
-		$this->assertInternalType('integer', $instance->get('foo', 0, 'INTEGER'));
-	}
-
-	/**
 	 * Test the Joomla\Input\Input::get method with float 0.0.
 	 *
 	 * @return  void

--- a/src/Input.php
+++ b/src/Input.php
@@ -180,7 +180,7 @@ class Input implements \Serializable, \Countable
 		{
 			$filteredValue = $this->filter->clean($this->data[$name], $filter);
 
-			if ($filteredValue)
+			if ($filteredValue === null)
 			{
 				return $filteredValue;
 			}

--- a/src/Input.php
+++ b/src/Input.php
@@ -178,7 +178,12 @@ class Input implements \Serializable, \Countable
 	{
 		if (isset($this->data[$name]))
 		{
-			return $this->filter->clean($this->data[$name], $filter);
+			$filteredValue = $this->filter->clean($this->data[$name], $filter);
+
+			if ($filteredValue)
+			{
+				return $filteredValue;
+			}
 		}
 
 		return $default;


### PR DESCRIPTION
With the introduction of https://github.com/joomla/joomla-framework/commit/200f4c20d8992146fd568f0771aff1dce7ab29ae the filtered value for an integer with a null string (or smilar) could return null. In the CMS for example it would return 0.

To deal with that we should return the default value of the input