### PR TITLE
Fix filling Input data with $_REQUEST vars

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -99,7 +99,7 @@ class Input implements \Serializable, \Countable
 			$this->filter = new Filter\InputFilter;
 		}
 
-		if (is_null($source))
+		if (is_null($source) || empty($source))
 		{
 			$this->data = &$_REQUEST;
 		}


### PR DESCRIPTION
Pull Request for Issue #23 

### Summary of Changes
$_REQUEST vars were not being added to the Input data array anymore because the constructor was still just checking if the $source variable was null. When they changed the default value of the $source var from null to an empty array, they forgot to also have it check if $source is now an empty array too.
