### PR TITLE
Deprecate CLI subclass support in favor of symfony/console API

### DIFF
--- a/src/Cli.php
+++ b/src/Cli.php
@@ -13,7 +13,8 @@ use Joomla\Filter;
 /**
  * Joomla! Input CLI Class
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use a Symfony\Component\Console\Input\InputInterface implementation when using the `joomla/console` package
  */
 class Cli extends Input
 {


### PR DESCRIPTION
When implementing the `joomla/console` package, there are two pain points in the package's design:

- Inability to extend `Symfony\Component\Console\Application` (which basically mandates we have to have our own base Application and Command classes with no ability to use the upstream classes or anything that might be compatible with `symfony/console`)
- Proxying `joomla/input` into `Symfony\Component\Console\Input\InputInterface` which in effect means there are two copies of the input data floating around (one inside `Joomla\Input\Cli` which isn't really kept in sync and the `Joomla\Console\Input\JoomlaInput` class which is a subclass of `Symfony\Component\Console\Input\ArgvInput` and is really the main input data source in this context)

This PR addresses one of those pain points, having to deal with the input API proxying, by just flat out deprecating our CLI input class for removal in 2.0.  Given the CLI application architecture is already gone in favor of the Console package, there really is no need to carry forward our "forced" use of our input API in a command line context.  Especially as the data in the `Joomla\Input\Cli` class falls out of sync with the data in the `Joomla\Console\Input\JoomlaInput` class pretty easily and doing a full bridge with data synchronization would be rather painful at best since the two APIs have two competing methodologies and no shared data source.