### PR TITLE
Use php 7.3 new setcookie method signature to allow SameSite cookie option

### DIFF
--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -38,42 +38,73 @@ class Cookie extends Input
 	 *
 	 * @param   string   $name      Name of the value to set.
 	 * @param   mixed    $value     Value to assign to the input.
-	 * @param   integer  $expire    The time the cookie expires. This is a Unix timestamp so is in number
-	 *                              of seconds since the epoch. In other words, you'll most likely set this
-	 *                              with the time() function plus the number of seconds before you want it
-	 *                              to expire. Or you might use mktime(). time()+60*60*24*30 will set the
-	 *                              cookie to expire in 30 days. If set to 0, or omitted, the cookie will
-	 *                              expire at the end of the session (when the browser closes).
-	 * @param   string   $path      The path on the server in which the cookie will be available on. If set
-	 *                              to '/', the cookie will be available within the entire domain. If set to
-	 *                              '/foo/', the cookie will only be available within the /foo/ directory and
-	 *                              all sub-directories such as /foo/bar/ of domain. The default value is the
-	 *                              current directory that the cookie is being set in.
-	 * @param   string   $domain    The domain that the cookie is available to. To make the cookie available
-	 *                              on all subdomains of example.com (including example.com itself) then you'd
-	 *                              set it to '.example.com'. Although some browsers will accept cookies without
-	 *                              the initial ., RFC 2109 requires it to be included. Setting the domain to
-	 *                              'www.example.com' or '.www.example.com' will make the cookie only available
-	 *                              in the www subdomain.
-	 * @param   boolean  $secure    Indicates that the cookie should only be transmitted over a secure HTTPS
-	 *                              connection from the client. When set to TRUE, the cookie will only be set
-	 *                              if a secure connection exists. On the server-side, it's on the programmer
-	 *                              to send this kind of cookie only on secure connection (e.g. with respect
-	 *                              to $_SERVER["HTTPS"]).
-	 * @param   boolean  $httpOnly  When TRUE the cookie will be made accessible only through the HTTP protocol.
-	 *                              This means that the cookie won't be accessible by scripting languages, such
-	 *                              as JavaScript. This setting can effectively help to reduce identity theft
-	 *                              through XSS attacks (although it is not supported by all browsers).
+	 * @param   array    $options   An associative array which may have any of the keys expires, path, domain,
+	 *                              secure, httponly and samesite. The values have the same meaning as described
+	 *                              for the parameters with the same name. The value of the samesite element
+	 *                              should be either Lax or Strict. If any of the allowed options are not given,
+	 *                              their default values are the same as the default values of the explicit
+	 *                              parameters. If the samesite element is omitted, no SameSite cookie attribute
+	 *                              is set.
 	 *
 	 * @return  void
 	 *
-	 * @link    http://www.ietf.org/rfc/rfc2109.txt
-	 * @see     setcookie()
-	 * @since   1.0
+	 * @link    https://www.ietf.org/rfc/rfc2109.txt
+	 * @link    https://php.net/manual/en/function.setcookie.php
+	 *
+	 * @since      1.0
+	 * @deprecated 2.0  The (name, value, expire, path, domain, secure, httpOnly) method signature is deprecated, use (name, value, options) instead.
 	 */
-	public function set($name, $value, $expire = 0, $path = '', $domain = '', $secure = false, $httpOnly = false)
+	public function set($name, $value, $options = [])
 	{
-		setcookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+		// BC layer to convert old method parameters.
+		if (is_array($options) === false)
+		{
+			$argList = func_get_args();
+
+			$options = [
+				'expires'  => isset($argList[2]) === true ? $argList[2] : 0,
+				'path'     => isset($argList[3]) === true ? $argList[3] : '',
+				'domain'   => isset($argList[4]) === true ? $argList[4] : '',
+				'secure'   => isset($argList[5]) === true ? $argList[5] : false,
+				'httponly' => isset($argList[6]) === true ? $argList[6] : false,
+			];
+		}
+
+		// Set the cookie
+		if (version_compare(PHP_VERSION, '7.3', '>='))
+		{
+			setcookie($name, $value, $options);
+		}
+		else
+		{
+			// Using the setcookie function before php 7.3, make sure we have default values.
+			if (array_key_exists('expires', $options) === false)
+			{
+				$options['expires'] = 0;
+			}
+
+			if (array_key_exists('path', $options) === false)
+			{
+				$options['path'] = '';
+			}
+
+			if (array_key_exists('domain', $options) === false)
+			{
+				$options['domain'] = '';
+			}
+
+			if (array_key_exists('secure', $options) === false)
+			{
+				$options['secure'] = false;
+			}
+
+			if (array_key_exists('httponly', $options) === false)
+			{
+				$options['httponly'] = false;
+			}
+
+			setcookie($name, $value, $options['expires'], $options['path'], $options['domain'], $options['secure'], $options['httponly']);
+		}
 
 		$this->data[$name] = $value;
 	}


### PR DESCRIPTION
### Summary of Changes

PHP 7.3 allows to use the SameSite option in cookie, for that the PHP setcookie method signature has changed in php 7.3, this chnage makes joomla framework input package more in line with PHP 7.3 setcookie function, allowing to use SameSite option and preserving BC at the same time.

References:
- https://php.net/manual/en/function.setcookie.php
- https://www.owasp.org/index.php/SameSite

### Testing Instructions

1. Code review
2. Test old method signature still works - make sure the cookie is always created
3. Test new method signature and also SameSite cookie parameter - make sure the cookie is always created

Example:
```php
use Joomla\Input\Input;

$input = new Input();

// New Method signature
$input->cookie->set('0', 'test');
$input->cookie->set('a', 'test', []);
$input->cookie->set('b', 'test', ['expires' => 1]);
$input->cookie->set('c', 'test', ['expires' => 1, 'path' => '/']);
$input->cookie->set('d', 'test', ['expires' => 1, 'path' => '/', 'domain' => 'test.com']);
$input->cookie->set('e', 'test', ['expires' => 1, 'path' => '/', 'domain' => 'test.com', 'secure' => true]);
$input->cookie->set('f', 'test', ['expires' => 1, 'path' => '/', 'domain' => 'test.com', 'secure' => true, 'httponly' => true]);

// New Method signature with samesite
$input->cookie->set('g', 'test', ['expires' => 1, 'path' => '/', 'domain' => 'test.com', 'secure' => true, 'httponly' => true, 'samesite' => 'Strict']);

// Old Method signature
$input->cookie->set('h', 'test', 1);
$input->cookie->set('i', 'test', 1, '/');
$input->cookie->set('j', 'test', 1, '/', 'test.com');
$input->cookie->set('k', 'test', 1, '/', 'test.com', true);
$input->cookie->set('l', 'test', 1, '/', 'test.com', true, true);
```

### Documentation Changes Required

None.