### PR TITLE
Restrict the values of the request method

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -349,7 +349,7 @@ class Input implements \Countable
 	 */
 	public function getMethod()
 	{
-		return strtoupper($this->server->getRaw('REQUEST_METHOD'));
+		return strtoupper($this->server->getCmd('REQUEST_METHOD'));
 	}
 
 	/**


### PR DESCRIPTION
I can't think of any request types where we don't match alphanumeric so this restricts the request method to be of that format. If we find during testing things go wrong we can always relax it a bit