### PR TITLE
Update Input.php

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -25,19 +25,19 @@ use Joomla\Filter;
  * @property-read    Files   $files
  * @property-read    Cookie  $cookie
  *
- * @method      integer  getInt($name, $default = null)       Get a signed integer.
- * @method      integer  getUint($name, $default = null)      Get an unsigned integer.
- * @method      float    getFloat($name, $default = null)     Get a floating-point number.
- * @method      boolean  getBool($name, $default = null)      Get a boolean value.
- * @method      string   getWord($name, $default = null)      Get a word.
- * @method      string   getAlnum($name, $default = null)     Get an alphanumeric string.
- * @method      string   getCmd($name, $default = null)       Get a CMD filtered string.
- * @method      string   getBase64($name, $default = null)    Get a base64 encoded string.
- * @method      string   getString($name, $default = null)    Get a string.
- * @method      string   getHtml($name, $default = null)      Get a HTML string.
- * @method      string   getPath($name, $default = null)      Get a file path.
- * @method      string   getUsername($name, $default = null)  Get a username.
- * @method      mixed    getRaw($name, $default = null)       Get an unfiltered value.
+ * @method      integer  getInt($name, $default = null)         Get a signed integer.
+ * @method      integer  getUint($name, $default = null)        Get an unsigned integer.
+ * @method      float    getFloat($name, $default = null)       Get a floating-point number.
+ * @method      boolean  getBool($name, $default = null)        Get a boolean value.
+ * @method      string   getWord($name, $default = null)        Get a word.
+ * @method      string   getAlnum($name, $default = null)       Get an alphanumeric string.
+ * @method      string   getCmd($name, $default = null)         Get a CMD filtered string.
+ * @method      string   getBase64($name, $default = null)      Get a base64 encoded string.
+ * @method      string   getString($name, $default = null)      Get a string.
+ * @method      string   getHtml($name, $default = null)        Get a HTML string.
+ * @method      string   getPath($name, $default = null)        Get a file path.
+ * @method      string   getUsername($name, $default = null)    Get a username.
+ * @method      mixed    getRaw($name = null, $default = null)  Get an unfiltered value.
  */
 class Input implements \Countable
 {


### PR DESCRIPTION
### Summary of Changes

`getRaw` is used in Joomla in many ways like:

```php
$data = json_decode($this->input->json->getRaw(), true);
```

in phpStorm, the `getRaw` method use, without specifying a $name param, shows as a warning, because the type hint doesn't allow null, when in fact the method allows its use (like Joomla consumes it above) 

The method `getRaw` in `Json` actually takes no params anyway so this is correct. 

I did not want to remove the $name and $default in case there is ever another type of input (like Json is) that extends and allows `getRaw` on a value like the hint says it should be able to.

This PR just adds the default of null to shut phpStorm up 

### Testing Instructions

None needed - should be able to merge on review

### Documentation Changes Required

None