### PR TITLE
 PHP 8.1 deprecation notices.

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -146,6 +146,7 @@ class Input implements \Countable
 	 * @since   1.0
 	 * @see     Countable::count()
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return \count($this->data);


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Silencing PHP 8.1 deprecation notices that prevents Joomla! from running with error reporting on.
Error message:
PHP Deprecated:  Return type of Joomla\Input\Input::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in D:\virtualhosts\clean40\libraries\vendor\joomla\input\src\Input.php on line 149

Snip from PHP.net Backward Incompatible Changes:

![image](https://user-images.githubusercontent.com/25645600/145462195-ae881c50-4240-4355-9d81-9522ac4f61a3.png)

### Testing Instructions
Code review or check that errors disappear from logfile
### Documentation Changes Required
Probably not.