### PR TITLE
Add default value NULL for method getArray() for notexist values in Input.php

### DIFF
--- a/Tests/InputTest.php
+++ b/Tests/InputTest.php
@@ -272,6 +272,8 @@ class InputTest extends TestCase
 
 		$input = $this->getInputObject($array);
 
+		$array['varNull'] = null;
+
 		$this->assertEquals(
 			$array,
 			$input->getArray(

--- a/Tests/InputTest.php
+++ b/Tests/InputTest.php
@@ -275,7 +275,7 @@ class InputTest extends TestCase
 		$this->assertEquals(
 			$array,
 			$input->getArray(
-				['var1' => 'string', 'var2' => 'int', 'var3' => 'array', 'var4' => ['var1' => ['var2' => 'array']]]
+				['var1' => 'string', 'var2' => 'int', 'var3' => 'array', 'var4' => ['var1' => ['var2' => 'array']], 'varNull' => 'string']
 			)
 		);
 	}

--- a/Tests/InputTest.php
+++ b/Tests/InputTest.php
@@ -272,12 +272,40 @@ class InputTest extends TestCase
 
 		$input = $this->getInputObject($array);
 
-		$array['varNull'] = null;
+		$this->assertEquals(
+			$array,
+			$input->getArray(
+				['var1' => 'string', 'var2' => 'int', 'var3' => 'array', 'var4' => ['var1' => ['var2' => 'array']]]
+			)
+		);
+	}
+
+	/**
+	 * @testdox  Tests that an array of keys are read from the data source with Null values
+	 *
+	 * @covers   Joomla\Input\Input
+	 */
+	public function testGetArrayWithNullFilterValues()
+	{
+		$this->filterMock->expects($this->any())
+			->method('clean')
+			->willReturnArgument(0);
+
+		$array = [
+			1 => 'value1',
+			2 => 34,
+			'varArr' => ['var1' => ['test']]
+		];
+
+		$input = $this->getInputObject($array);
+
+		$array[0] = null;
+		$array['varArr']['var1'][1] = null;
 
 		$this->assertEquals(
 			$array,
 			$input->getArray(
-				['var1' => 'string', 'var2' => 'int', 'var3' => 'array', 'var4' => ['var1' => ['var2' => 'array']], 'varNull' => 'string']
+				[0 => 'int', 1 => 'string', 2 => 'int', 'varArr' => ['var1' => [0 => 'string', 1 => 'string']]]
 			)
 		);
 	}

--- a/src/Input.php
+++ b/src/Input.php
@@ -205,7 +205,7 @@ class Input implements \Countable
 				}
 				else
 				{
-					$results[$k] = $this->getArray($v, $datasource[$k]);
+					$results[$k] = $this->getArray($v, $datasource[$k] ?? null);
 				}
 			}
 			else


### PR DESCRIPTION
for a single Input value, it is possible to set a default value. But for the value in the array, there is no such possibility. And it is also a tragedy when a non-existent field in the array causes an error. Firstly, we do not have the ability to apply the default value, but in addition an error is caused.
``` HTML
<input name="user[name][1]" ......... >
<input name="user[name][2]" ......... >
```
``` PHP
$arrFilter = ['user'=> ['name'=> [ 0 => 'STRING', 1 => 'STRING', 2 => 'STRING' ] ] ];
$input = new Joomla\Input\Input();
$data = $input->getArray($arrFilter);
```
The **`$data`** variable should return all the request fields after processing the STRING filter.
But we see that the filter keys have other indexes in the array. Such code will cause an error.
Since there is no field with index 0 in the request.
As an alternative, we don't have the option to set default values. Therefore, the **`getArray()`** method should return the default value **`NULL`**. Thanks to this, we can later check for the presence of a value with an index of 0.
All simple methods always return **`NULL`** by default. Methods such as **`getInt()`**, **`getString()`**, **`getCmd()`**, **`getHtml()`** and others return **`NULL`**. But the **`getArray()`** method for a nonexistent field causes an error.

**But:** 
This amendment cannot violate backward compatibility. Since the amendment corrects the error message. And I can also conclude that this method is not used by anyone. Since I didn't find any documentation on how this method works in the Joomla Doc help. Which means that developers do not use this method at all. Developers use simple methods. **`getInt()`**, **`getCmd()`**...
Otherwise, this error would have been discovered long ago.