### PR TITLE
PHPDoc for Json input

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -24,6 +24,7 @@ use Joomla\Filter;
  * @property-read    Input   $env
  * @property-read    Files   $files
  * @property-read    Cookie  $cookie
+ * @property-read    Json    $json
  *
  * @method      integer  getInt($name, $default = null)       Get a signed integer.
  * @method      integer  getUint($name, $default = null)      Get an unsigned integer.


### PR DESCRIPTION
### Summary of Changes

`$app->input->json` and `$app->input->json->getRaw()` are incorrectly parsed by IDE.

### Testing Instructions

Check `$app->input->json` and `$app->input->json->getRaw()` calls in IDE.

### Documentation Changes Required

No.